### PR TITLE
[ML] 머신러닝 프로토타입 구현

### DIFF
--- a/app/pages/machine.py
+++ b/app/pages/machine.py
@@ -7,10 +7,8 @@ import plotly.express as px
 from sklearn.model_selection import train_test_split
 from sklearn.ensemble import RandomForestClassifier
 
-
 @st.cache_data
 def load_data():
-
     data = pd.DataFrame({
         "dong": ["대연동","용호동","문현동","감만동","우암동"],
         "population": [30000, 45000, 20000, 15000, 5000],
@@ -18,13 +16,11 @@ def load_data():
         "toilets": [5, 7, 2, 1, 0],
         "accessible": [3, 4, 1, 0, 0]
     })
-
     data["toilet_ratio"] = data["toilets"] / data["population"]
-    data["label"] = (data["toilet_ratio"] < 0.0002).astype(int)  # 1=부족, 0=적정
+    data["label"] = (data["toilet_ratio"] < 0.0005).astype(int)
     return data
 
 df = load_data()
-
 
 X = df[["population","floating","toilets","accessible"]]
 y = df["label"]
@@ -35,24 +31,24 @@ model = RandomForestClassifier(random_state=42)
 model.fit(X_train, y_train)
 
 df["prediction"] = model.predict(X)
-df["probability"] = model.predict_proba(X)[:,1]  # 부족일 확률
-
+proba = model.predict_proba(X)
+if proba.shape[1] == 1:
+    df["probability"] = proba[:,0]
+else:
+    df["probability"] = proba[:,1]
 
 st.set_page_config(page_title="공중화장실 데이터맵", layout="wide")
 
 st.title("🚻 공중화장실 데이터맵 + 머신러닝 예측")
 
-
 st.subheader("📊 원본 데이터")
 st.dataframe(df)
-
 
 st.subheader("📈 행정동별 인구 대비 화장실 수")
 fig = px.bar(df, x="dong", y="toilet_ratio", color="label",
              labels={"dong":"행정동","toilet_ratio":"인구 대비 화장실 비율"},
              title="행정동별 화장실 비율 (빨강=부족, 파랑=적정)")
 st.plotly_chart(fig, use_container_width=True)
-
 
 coords = {
     "대연동": (35.133, 129.101),
@@ -84,7 +80,6 @@ for _, row in df.iterrows():
     ).add_to(m)
 
 st_folium(m, width=800, height=500)
-
 
 st.subheader("🃏 머신러닝 예측 카드")
 for _, row in df.iterrows():

--- a/app/pages/machine.py
+++ b/app/pages/machine.py
@@ -2,7 +2,6 @@ import streamlit as st
 import pandas as pd
 import folium
 from streamlit_folium import st_folium
-from geopy.distance import geodesic
 import plotly.express as px
 from sklearn.model_selection import train_test_split
 from sklearn.ensemble import RandomForestClassifier
@@ -17,7 +16,8 @@ def load_data():
         "accessible": [3, 4, 1, 0, 0]
     })
     data["toilet_ratio"] = data["toilets"] / data["population"]
-    data["label"] = (data["toilet_ratio"] < 0.0005).astype(int)
+    threshold = data["toilet_ratio"].quantile(0.4)
+    data["label"] = (data["toilet_ratio"] < threshold).astype(int)
     return data
 
 df = load_data()

--- a/app/pages/machine.py
+++ b/app/pages/machine.py
@@ -45,9 +45,15 @@ st.subheader("📊 원본 데이터")
 st.dataframe(df)
 
 st.subheader("📈 행정동별 인구 대비 화장실 수")
-fig = px.bar(df, x="dong", y="toilet_ratio", color="label",
-             labels={"dong":"행정동","toilet_ratio":"인구 대비 화장실 비율"},
-             title="행정동별 화장실 비율 (빨강=부족, 파랑=적정)")
+fig = px.bar(
+    df,
+    x="dong",
+    y="toilet_ratio",
+    color="probability",  # 부족 확률 기준으로 색상
+    color_continuous_scale=["green", "yellow", "red"],
+    labels={"dong":"행정동","toilet_ratio":"인구 대비 화장실 비율","probability":"부족 확률"},
+    title="행정동별 화장실 비율 (초록→빨강 그라데이션: 부족 확률)"
+)
 st.plotly_chart(fig, use_container_width=True)
 
 coords = {

--- a/app/pages/machine.py
+++ b/app/pages/machine.py
@@ -1,0 +1,92 @@
+import streamlit as st
+import pandas as pd
+import folium
+from streamlit_folium import st_folium
+from geopy.distance import geodesic
+import plotly.express as px
+from sklearn.model_selection import train_test_split
+from sklearn.ensemble import RandomForestClassifier
+
+
+@st.cache_data
+def load_data():
+
+    data = pd.DataFrame({
+        "dong": ["대연동","용호동","문현동","감만동","우암동"],
+        "population": [30000, 45000, 20000, 15000, 5000],
+        "floating": [5000, 8000, 2000, 1000, 500],
+        "toilets": [5, 7, 2, 1, 0],
+        "accessible": [3, 4, 1, 0, 0]
+    })
+
+    data["toilet_ratio"] = data["toilets"] / data["population"]
+    data["label"] = (data["toilet_ratio"] < 0.0002).astype(int)  # 1=부족, 0=적정
+    return data
+
+df = load_data()
+
+
+X = df[["population","floating","toilets","accessible"]]
+y = df["label"]
+
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.3, random_state=42)
+
+model = RandomForestClassifier(random_state=42)
+model.fit(X_train, y_train)
+
+df["prediction"] = model.predict(X)
+df["probability"] = model.predict_proba(X)[:,1]  # 부족일 확률
+
+
+st.set_page_config(page_title="공중화장실 데이터맵", layout="wide")
+
+st.title("🚻 공중화장실 데이터맵 + 머신러닝 예측")
+
+
+st.subheader("📊 원본 데이터")
+st.dataframe(df)
+
+
+st.subheader("📈 행정동별 인구 대비 화장실 수")
+fig = px.bar(df, x="dong", y="toilet_ratio", color="label",
+             labels={"dong":"행정동","toilet_ratio":"인구 대비 화장실 비율"},
+             title="행정동별 화장실 비율 (빨강=부족, 파랑=적정)")
+st.plotly_chart(fig, use_container_width=True)
+
+
+coords = {
+    "대연동": (35.133, 129.101),
+    "용호동": (35.120, 129.118),
+    "문현동": (35.145, 129.068),
+    "감만동": (35.129, 129.075),
+    "우암동": (35.115, 129.082),
+}
+
+st.subheader("🗺️ 공중화장실 부족 지역 지도")
+m = folium.Map(location=[35.13,129.10], zoom_start=13)
+
+for _, row in df.iterrows():
+    lat, lon = coords[row["dong"]]
+    color = "red" if row["prediction"]==1 else "green"
+    popup = f"""
+    <b>{row['dong']}</b><br>
+    인구: {row['population']}명<br>
+    화장실 수: {row['toilets']}개<br>
+    부족확률: {row['probability']*100:.1f}%
+    """
+    folium.CircleMarker(
+        location=(lat, lon),
+        radius=12,
+        color=color,
+        fill=True,
+        fill_opacity=0.6,
+        popup=popup
+    ).add_to(m)
+
+st_folium(m, width=800, height=500)
+
+
+st.subheader("🃏 머신러닝 예측 카드")
+for _, row in df.iterrows():
+    status = "부족" if row["prediction"]==1 else "적정"
+    st.metric(label=row["dong"], value=f"{status} ({row['probability']*100:.1f}%)")


### PR DESCRIPTION
## #️⃣연관된 이슈

> 17

## 📝작업 내용

>머신러닝 학습
>예측 결과 출력
“대연동 → 부족 (78%)” 같은 카드형 UI
지도 오버레이:
부족 지역 = 빨강
적정 지역 = 초록
지도 기반 시각화 (Folium / streamlit-folium)
차트 시각화 (Plotly, Seaborn)


<img width="1855" height="665" alt="image" src="https://github.com/user-attachments/assets/831a3062-3d1f-4fa0-bd6d-aec55d30e41f" />

<img width="1152" height="734" alt="image" src="https://github.com/user-attachments/assets/74e5ecdf-7654-45ba-a4ff-c31e6388d4f2" />

<img width="604" height="754" alt="image" src="https://github.com/user-attachments/assets/29563233-974f-440e-908f-8459e87ef397" />


## 🫡 참고사항

추후 UI/UX 설계 후 디자인 변경 예정 .. 
진짜 순수한 기능만 구현했습니다 디자인은 눈감아주세여....
